### PR TITLE
Remove tip of WA

### DIFF
--- a/fivethirtyeight.js
+++ b/fivethirtyeight.js
@@ -13,7 +13,7 @@ var options = {
     top: 340,
     left: 250,
     right: 250,
-    bottom: 550
+    bottom: 545
   },
   shotSize: {
     width: 'window',


### PR DESCRIPTION
![screen shot 2016-10-19 at 09 39 06](https://cloud.githubusercontent.com/assets/6593577/19512561/78058e78-95e4-11e6-912e-ea20ba91139f.png)

Washington is beautiful, but the little bit of blue in the screenshot is a bit distracting from Hill's lead. ;) 

This PR changes the bottom value of `shotOffset` to 545, which should remove it. It may actually need to be 555, but I wasn't entirely sure how to test this. 

Thanks for building this bot! It's definitely keeping me more sane these final weeks of the election!  
